### PR TITLE
Update DB name so we have the same one

### DIFF
--- a/.env
+++ b/.env
@@ -11,6 +11,6 @@ DB_HOST=127.0.0.1
 DB_PORT=5432
 DB_USER=docker
 DB_PASSWORD=docker
-DB_DATABASE=rentApi
+DB_DATABASE=rentapi
 
 HASH_DRIVER=bcrypt


### PR DESCRIPTION
#### Description
Since we have added the `.env` file in the repo, we should have the same db name to avoid conflicts.
Even if I try to create a DB called `rentApi`, it forces to be all lower case, in this case we should both have `rentapi` as our DB name.

#### Steps to reproduce
- From this branch logs into the postgres image.
`psql -h localhost -p 5432 -d <IMAGE_NAME> -U docker` with password `docker`
- Then type `\l` to list the databases
- Make sure the api server is not running
- Then change the name of the DB by executing the following:
`ALTER DATABASE YOUR_DB_NAME RENAME TO rentapi;`

#### Risks
* Low: it just changes the DB name in `.env`, migrations might fail
* Rollback Steps: (Safe to deploy previous tag).